### PR TITLE
feat: add chitin.rb formula

### DIFF
--- a/Formula/chitin.rb
+++ b/Formula/chitin.rb
@@ -1,0 +1,57 @@
+# typed: false
+# frozen_string_literal: true
+
+class Chitin < Formula
+  desc "Programmable control plane for AI coding agents — kernel, gate, soul, session"
+  homepage "https://github.com/chitinhq/chitin"
+  version "0.1.0"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/chitinhq/chitin/releases/download/v0.1.0/chitin-darwin-arm64"
+      sha256 "d45757d44793dd2296a2753ceb299cd5b2620104e1c71e8d2192de73c72f240c"
+    end
+    on_intel do
+      url "https://github.com/chitinhq/chitin/releases/download/v0.1.0/chitin-darwin-amd64"
+      sha256 "9ba970fd2fc5e2b10c75a84c668cef5905fcfc7b9f60626e63ccce581a439c19"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/chitinhq/chitin/releases/download/v0.1.0/chitin-linux-arm64"
+      sha256 "ee6a50e3d866a6e9e2bcabcc40eae5c7ea82a875b9b42eebcab4148ca3b2dd17"
+    end
+    on_intel do
+      url "https://github.com/chitinhq/chitin/releases/download/v0.1.0/chitin-linux-amd64"
+      sha256 "b3bef80591e8f4a41c932fff4b7191e67a75585c2e610b5882a753d2ade074a5"
+    end
+  end
+
+  def install
+    # Release assets are raw binaries named `chitin-<os>-<arch>`.
+    # Rename to `chitin` on install.
+    binary = Dir["chitin-*"].first
+    bin.install binary => "chitin"
+  end
+
+  def caveats
+    <<~EOS
+      Chitin is the governance kernel for AI coding agents.
+
+      Get started:
+        chitin init claude     # or: copilot, codex, gemini
+        chitin status
+        chitin evaluate -t Bash -c "git status"
+
+      Companion tools in this tap:
+        brew install chitinhq/tap/clawta       # governed coding agent
+        brew install chitinhq/tap/shellforge   # local Ollama runtime
+    EOS
+  end
+
+  test do
+    assert_match "chitin", shell_output("#{bin}/chitin version")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Formula/chitin.rb` so `brew install chitinhq/tap/chitin` works on a stranger's Mac.
- Uses prebuilt v0.1.0 release binaries across darwin/linux x arm64/amd64 — no Go toolchain required at install time.
- SHA256s computed from the actual release assets at `github.com/chitinhq/chitin/releases/tag/v0.1.0` (not fabricated).
- Install promise in `chitin/GETTING_STARTED.md:35-36` (`brew tap chitinhq/tap`) now has a chitin target to match.

## Notes
- Assets are raw binaries named `chitin-<os>-<arch>` (not tarballs), so the install block renames to `chitin` via `bin.install binary => "chitin"`.
- A v0.2.0 tag exists in the chitin repo but has no GitHub release; sticking with v0.1.0 until release artifacts exist for it.
- Mirrors shellforge.rb's prebuilt pattern rather than clawta.rb's source-build pattern for better stranger-Mac UX.

## Test plan
- [ ] `brew audit --strict Formula/chitin.rb` (macOS required — implementer is on Linux)
- [ ] `brew install --build-from-source ./Formula/chitin.rb` on a macOS box
- [ ] `chitin version` returns a non-empty string
- [ ] `brew install chitinhq/tap/chitin` after merge on a fresh Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)